### PR TITLE
fix(build): remove Gradle deprecations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ android {
             buildConfigField "String", "ADMOB_SINGLE_CASE_QUIZ_INTERSTITIAL_AD_UNIT_ID", "\"ca-app-pub-6420074467468909/9608497598\""
             manifestPlaceholders = [admobAppId: "ca-app-pub-6420074467468909~9307588615"]
             firebaseCrashlytics {
-                nativeSymbolUploadEnabled true
+                nativeSymbolUploadEnabled = true
             }
         }
     }
@@ -71,14 +71,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':database')
+    implementation(project.getDependencyFactory().createProjectDependency(':database'))
     implementation 'androidx.appcompat:appcompat:1.8.0'
     implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.browser:browser:1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '9.2.1' apply false
-    id 'com.android.library' version '9.2.1' apply false
+    id 'com.android.application' version '9.3.0' apply false
+    id 'com.android.library' version '9.3.0' apply false
     id 'com.google.gms.google-services' version '4.5.0' apply false
     id 'com.google.firebase.crashlytics' version '3.0.7' apply false
 }

--- a/database/src/main/java/com/usharik/database/dao/DatabaseFactory.java
+++ b/database/src/main/java/com/usharik/database/dao/DatabaseFactory.java
@@ -1,7 +1,6 @@
 package com.usharik.database.dao;
 
 import android.content.Context;
-import com.usharik.database.DocumentRepository;
 
 /**
  * Created by macbook on 14/03/2018.
@@ -12,11 +11,5 @@ public class DatabaseFactory {
     /** Returns the shared {@link DocumentDatabase} instance. */
     public static DocumentDatabase provideDocumentDatabase(Context context) {
         return DocumentDatabase.getDocumentDatabase(context);
-    }
-
-    /** @deprecated Use {@link #provideDocumentDatabase(Context)} to share one DB instance. */
-    @Deprecated
-    public static DocumentRepository provideDocumentDb(Context context) {
-        return new DocumentRepository(DocumentDatabase.getDocumentDatabase(context));
     }
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -20,7 +20,7 @@ jar {
 
 dependencies {
     sourceSets.main.java.srcDirs = ['src']
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation 'junit:junit:4.13.2'
     implementation 'org.xerial:sqlite-jdbc:3.53.2.1'
     implementation 'com.google.code.gson:gson:2.14.0'
 }


### PR DESCRIPTION
Removes Gradle deprecations, migrates Data Binding to buildFeatures, updates AGP to 9.3.0, and removes an unused deprecated factory method. Validation: ./gradlew help --warning-mode all completes with no deprecation warnings.