### PR TITLE
Fix Android SDK setup in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Accept Android SDK licenses
         run: yes | sdkmanager --licenses || true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -42,7 +42,7 @@ jobs:
           appium --version
       
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
       
       - name: Accept Android SDK licenses
         run: yes | sdkmanager --licenses || true
@@ -207,4 +207,3 @@ jobs:
             } catch (error) {
               console.log('Unable to comment on PR (this is expected for Dependabot PRs):', error.message);
             }
-


### PR DESCRIPTION
## Summary
- update android-actions/setup-android from v3 to v4 in APK build workflow
- update the same action in UI tests workflow

## Validation
- Gradle task :app:lintVitalRelease passed locally
- Build APKs workflow passed with the updated setup action

Fixes the GitHub-hosted runner failure while installing the obsolete Android SDK tools package.